### PR TITLE
Removed requirement for Ensembl API unless ontology option is specified.

### DIFF
--- a/scripts/variant_effect_predictor/filter_vep.pl
+++ b/scripts/variant_effect_predictor/filter_vep.pl
@@ -576,7 +576,9 @@ sub filter_is_child {
     
     # connect to DBs here
     if(!defined($config->{ontology_adaptor})) {
-      eval "use Bio::EnsEMBL::Registry;";
+      eval {
+	    require Bio::EnsEMBL::Registry;
+	  }
       
       if($@) {
         die("ERROR: Could not load Ensembl API modules\n");


### PR DESCRIPTION
The intention of this conditional eval seems to be that the user does not need the Ensembl API installed unless they want to use the ontology option. However with the block form of eval this does not work - it throws an error complaining about the missing module whether ontology is used or not. By using string eval the script runs fine without Ensembl API (unless ontology is used - in which case the intended error is thrown).
