### PR TITLE
Changed use to require to avoid compile time dependency on Ensembl API

### DIFF
--- a/scripts/variant_effect_predictor/filter_vep.pl
+++ b/scripts/variant_effect_predictor/filter_vep.pl
@@ -577,8 +577,8 @@ sub filter_is_child {
     # connect to DBs here
     if(!defined($config->{ontology_adaptor})) {
       eval {
-	    require Bio::EnsEMBL::Registry;
-	  }
+        require Bio::EnsEMBL::Registry;
+      };
       
       if($@) {
         die("ERROR: Could not load Ensembl API modules\n");


### PR DESCRIPTION
Avoids the need for Ensembl API installation if running script without ontology option.
