### PR TITLE
Explitictly set passive FTP mode for firewalled client connections

### DIFF
--- a/scripts/variant_effect_predictor/INSTALL.pl
+++ b/scripts/variant_effect_predictor/INSTALL.pl
@@ -436,7 +436,7 @@ sub cache() {
 
   if($CACHE_URL =~ /^ftp/i) {
     $CACHE_URL =~ m/(ftp:\/\/)?(.+?)\/(.+)/;
-    $ftp = Net::FTP->new($2) or die "ERROR: Could not connect to FTP host $2\n$@\n";
+    $ftp = Net::FTP->new($2, Passive => 1) or die "ERROR: Could not connect to FTP host $2\n$@\n";
     $ftp->login($FTP_USER) or die "ERROR: Could not login as $FTP_USER\n$@\n";
     $ftp->binary();
   
@@ -671,7 +671,7 @@ sub fasta() {
 
   if($FASTA_URL =~ /^ftp/i) {
     $FASTA_URL =~ m/(ftp:\/\/)?(.+?)\/(.+)/;
-    $ftp = Net::FTP->new($2) or die "ERROR: Could not connect to FTP host $2\n$@\n";
+    $ftp = Net::FTP->new($2, Passive => 1) or die "ERROR: Could not connect to FTP host $2\n$@\n";
     $ftp->login($FTP_USER) or die "ERROR: Could not login as $FTP_USER\n$@\n";
     $ftp->binary();
   


### PR DESCRIPTION
Users behind firewalls/NAT can't list and download cache/fasta files without passive mode FTP.