### PR TITLE
Avoid VEP to delete INFO headers it should not

### DIFF
--- a/scripts/variant_effect_predictor/variant_effect_predictor.pl
+++ b/scripts/variant_effect_predictor/variant_effect_predictor.pl
@@ -1945,7 +1945,7 @@ sub get_out_file_handle {
             # nuke existing CSQ header unless we are keeping it
             unless(defined($config->{keep_csq})) {
               my $vcf_field = $config->{vcf_info_field};
-              @{$config->{headers}} = grep {!/$vcf_field/} @{$config->{headers}};
+              @{$config->{headers}} = grep {!/^##INFO=<ID=$vcf_field,/} @{$config->{headers}};
             }
             
             for my $i(0..$#{$config->{headers}}) {


### PR DESCRIPTION
I got in trouble using VCF files from Illumina because of missing headers. VEP has a naive way of detecting old CSQ fields (when not using --keep_csq) so it deletes:
 * ##INFO=<ID=CSQT,Number=.,Type=...
 * ##INFO=<ID=CSQR,Number=.,Type=...
Actually, any header which contains "CSQ" in any part (the Description for example) would be deleted. I just changed that to be really specific.